### PR TITLE
FIX: deprecated property in sdk 5.1.0

### DIFF
--- a/styles/window.tss
+++ b/styles/window.tss
@@ -21,7 +21,7 @@
 	layout: 'vertical'
 },
 ".cfn_LoaderIndicator": {
-	style: Ti.UI.iPhone.ActivityIndicatorStyle.BIG,
+	style: Ti.UI.ActivityIndicatorStyle.BIG,
 	color: '#fff'
 },
 ".cfn_LoaderLabel": {


### PR DESCRIPTION
Removes the warning message from console "Titanium.UI.iPhone.ActivityIndicatorStyle.BIG DEPRECATED in 5.1.0"
