### PR TITLE
Fix: Loader fit all the width screen

### DIFF
--- a/views/window.xml
+++ b/views/window.xml
@@ -2,7 +2,7 @@
 	<Window id="cfn_LoaderMask" class="cfn_LoaderMask">
 		<View id="cfn_LoaderView" class="cfn_LoaderView">
 			<View id="cfn_LoaderViewInset" class="cfn_LoaderViewInset">
-				<View id="cfn_Method" height="Ti.UI.SIZE">
+				<View id="cfn_Method" height="Ti.UI.SIZE" width="Ti.UI.SIZE">
 					<ActivityIndicator id="cfn_LoaderIndicator" class="cfn_LoaderIndicator" />
 					<ImageView id="cfn_LoaderImages" class="cfn_LoaderImages" />
 				</View>


### PR DESCRIPTION
The loader fits all the screen always, with this modification the loader fit the text inside the loader.
